### PR TITLE
[Streeteasy] Add support for Streeteasy listings

### DIFF
--- a/openerManifest-v5.json
+++ b/openerManifest-v5.json
@@ -5507,6 +5507,25 @@
             ]
         },
         {
+            "title": "Open Listing",
+            "regex": "https?://(?:\\w+\\.)?streeteasy\\.com/sale/(\\d+)$",
+            "testInputs": [
+                "https://streeteasy.com/sale/1544178",
+                "https://streeteasy.com/building/atelier-condominium/9b"
+            ],
+            "formats": [
+                {
+                    "appId": "streeteasy",
+                    "format": "streeteasy://$1",
+                    "script2": "function process(url, completionHandler) { var results = RegExp('ios-app://660363289/streeteasy/([^\\']+)\\'').exec(url); var match = results != null && results.length > 1 ? 'streeteasy://' + results[1] : null; completionHandler(match); }",
+                    "testResults": [
+                        "streeteasy://sale/1544178",
+                        "streeteasy://rental/2770017"
+                    ]
+                }
+            ]
+        },
+        {
             "title": "Open Illustration",
             "regex": "https?(://(?:\\w+\\.)?pixiv\\.net/(?:(?:.+/)?artworks/|member_illust\\.php?.*illust_id=)(\\d+).*)$",
             "testInputs": [


### PR DESCRIPTION
* [Streeteasy](https://streeteasy.com/) is a Zillow owned app for the NYC-area real estate market
* This adds support to extract the iOS deeplink from the alternate URL
  on the page

## Manual Regex Test

![image](https://user-images.githubusercontent.com/5719/124530235-221f0780-ddda-11eb-8c32-791c6fd8b7f4.png)
